### PR TITLE
archon-exec: set the ARCHON_CURRENTDIR variable

### DIFF
--- a/archon-exec
+++ b/archon-exec
@@ -7,6 +7,9 @@
 # Version: 1.2
 #
 
+# Current directory
+ARCHON_CURRENTDIR="$PWD"
+
 # The APK installation directory
 ARCHON_APKROOT=${ARCHON_APKROOT:='/tmp/archon'}
 
@@ -75,7 +78,7 @@ function create_appdir() {
     pushd "$ARCHON_APKROOT/$checksum" >/dev/null
 
     # Generate the APK folder using chromeos-apk
-    chromeos-apk -a --tablet "$1" >chromeos-apk.log
+    chromeos-apk -a --tablet "$ARCHON_CURRENTDIR"/"$1" >chromeos-apk.log
 
     # Fix the "There is no message element for key extName" error
     grep -qr 'appNotSupported' && {


### PR DESCRIPTION
The variable is meant to record the current directory, $PWD in a variable to allow archon-exec to run .apk's without specifying the absolute directory of the apk file.

Before the change, archon-exec will hang with no warning or error when running something like...

$ archon-exec com.corporate.robbery.apk

And now it should be able to do it.
